### PR TITLE
warning output if parameter does not exist

### DIFF
--- a/roscpp_nodewrap/include/roscpp_nodewrap/NodeImpl.h
+++ b/roscpp_nodewrap/include/roscpp_nodewrap/NodeImpl.h
@@ -28,6 +28,7 @@
 #include <boost/enable_shared_from_this.hpp>
 
 #include <ros/console.h>
+#include <roscpp_nodewrap/Console.h>
 
 #include <roscpp_nodewrap/Publisher.h>
 #include <roscpp_nodewrap/PublisherOptions.h>
@@ -128,6 +129,19 @@ namespace nodewrap {
       */
     template <typename T> T getParam(const std::string& key, const T&
       defaultValue) const;
+
+    /** \brief Retrieve a parameter value from the parameter server. Use warning output if parameter does not exist.
+      *
+      * \param[in] key The key referring to the parameter whose value
+      *   shall be retrieved.
+      * \param[in] defaultValue The default value of the parameter.
+      * \return The actual value of the parameter if the parameter
+      *   has been defined or the default value otherwise.
+      *
+      * \see ros::NodeHandle::getParam
+      */
+    template <typename T> T getParamWithWarning(const std::string& key,
+      const T& defaultValue) const;
     
     /** \brief Query if the node(let) is a ROS nodelet
       * 

--- a/roscpp_nodewrap/include/roscpp_nodewrap/NodeImpl.tpp
+++ b/roscpp_nodewrap/include/roscpp_nodewrap/NodeImpl.tpp
@@ -41,7 +41,7 @@ template <typename T> T NodeImpl::getParamWithWarning(const std::string& key,
 
   if(!this->getNodeHandle().hasParam(key) || !this->getNodeHandle().getParam(key, value))
   {
-    NODEWRAP_WARN_STREAM("Parameter " << key << " not found. Using default value.");
+    NODEWRAP_WARN_STREAM("[" <<this->getName()<<"]: Parameter " << key << " not found. Using default value.");
     value = defaultValue;
   }
 

--- a/roscpp_nodewrap/include/roscpp_nodewrap/NodeImpl.tpp
+++ b/roscpp_nodewrap/include/roscpp_nodewrap/NodeImpl.tpp
@@ -35,6 +35,20 @@ template <typename T> T NodeImpl::getParam(const std::string& key,
   return value;
 }
 
+template <typename T> T NodeImpl::getParamWithWarning(const std::string& key,
+    const T& defaultValue) const {
+  T value;
+
+  if(!this->getNodeHandle().hasParam(key) || !this->getNodeHandle().getParam(key, value))
+  {
+    NODEWRAP_WARN_STREAM("Parameter " << key << " not found. Using default value.");
+    value = defaultValue;
+  }
+
+  return value;
+}
+
+
 /*****************************************************************************/
 /* Methods                                                                   */
 /*****************************************************************************/


### PR DESCRIPTION
Probably also [param_io](https://bitbucket.org/ethz-asl-lr/any_common) could be included for checking the validity of the parameters. However this would introduce message dependencies. 